### PR TITLE
04: Authentication Socials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "react-day-picker": "^9.9.0",
         "react-dom": "19.1.0",
         "react-hook-form": "^7.62.0",
+        "react-icons": "^5.5.0",
         "react-resizable-panels": "^3.0.5",
         "recharts": "^2.15.4",
         "sonner": "^2.0.7",
@@ -8384,6 +8385,15 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-day-picker": "^9.9.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
+    "react-icons": "^5.5.0",
     "react-resizable-panels": "^3.0.5",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",

--- a/src/app/(auth)/sign-in/page.tsx
+++ b/src/app/(auth)/sign-in/page.tsx
@@ -1,5 +1,18 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+import { headers } from "next/headers";
+
 import { SignInView } from "@/modules/auth/ui/views/sign-in-view";
 
-export default function SignInPage() {
+export default async function SignInPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!!session) {
+    return redirect("/");
+  }
+
   return <SignInView />;
 }

--- a/src/app/(auth)/sign-up/page.tsx
+++ b/src/app/(auth)/sign-up/page.tsx
@@ -1,5 +1,18 @@
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+
+import { headers } from "next/headers";
+
 import { SignUpView } from "@/modules/auth/ui/views/sign-up-view";
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!!session) {
+    return redirect("/");
+  }
+
   return <SignUpView />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,89 +1,17 @@
-"use client";
+import { headers } from "next/headers";
 
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { useState } from "react";
-import { authClient } from "@/lib/auth-client";
+import { auth } from "@/lib/auth";
+import { HomeView } from "@/modules/home/ui/views/home-view";
+import { redirect } from "next/navigation";
 
-export default function Home() {
-  const { data: session } = authClient.useSession();
+export default async function Page() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
 
-  const [name, setName] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-
-  const onSubmit = async () => {
-    await authClient.signUp.email(
-      {
-        email,
-        password,
-        name,
-      },
-      {
-        onSuccess: () => {
-          window.alert("User created successfully");
-        },
-        onError: () => {
-          window.alert("Something went wrong");
-        },
-      }
-    );
-  };
-
-  const onSignIn = async () => {
-    await authClient.signIn.email({
-      email,
-      password,
-    });
-  };
-
-  if (session) {
-    return (
-      <div className="flex flex-col p-4 gap-y-4">
-        <p>Logged in as {session.user?.name}</p>
-        <Button onClick={() => authClient.signOut()}>Sign Out</Button>
-      </div>
-    );
+  if (!session) {
+    return redirect("/sign-in");
   }
 
-  return (
-    <div className="flex flex-col gap-y-10">
-      <div className="flex flex-col gap-y-4 p-4">
-        <Input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={onSignIn}>Sign In</Button>
-      </div>
-      <div className="flex flex-col gap-y-4 p-4">
-        <Input
-          type="text"
-          placeholder="Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <Input
-          type="email"
-          placeholder="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <Input
-          type="password"
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <Button onClick={onSubmit}>Create User</Button>
-      </div>
-    </div>
-  );
+  return <HomeView />;
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,16 @@ import { db } from "@/db";
 import * as schema from "@/db/schema";
 
 export const auth = betterAuth({
+  socialProviders: {
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID as string,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET as string,
+    },
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+    },
+  },
   emailAndPassword: {
     enabled: true,
   },

--- a/src/modules/auth/ui/views/sign-in-view.tsx
+++ b/src/modules/auth/ui/views/sign-in-view.tsx
@@ -7,12 +7,12 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { OctagonAlertIcon } from "lucide-react";
+import { FaGithub, FaGoogle } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertTitle } from "@/components/ui/alert";
-import { useRouter } from "next/navigation";
 
 import {
   Form,
@@ -36,7 +36,6 @@ const formSchema = z.object({
 });
 
 export const SignInView = () => {
-  const router = useRouter();
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
 
@@ -56,11 +55,11 @@ export const SignInView = () => {
       {
         email: values.email,
         password: values.password,
+        callbackURL: "/",
       },
       {
         onSuccess: () => {
           setPending(false);
-          router.push("/");
         },
         onError: ({ error }) => {
           setError(error.message);
@@ -68,6 +67,27 @@ export const SignInView = () => {
       }
     );
   }
+
+  const onSocial = (provider: "github" | "google") => {
+    setError(null);
+    setPending(true);
+
+    authClient.signIn.social(
+      {
+        provider: provider,
+        callbackURL: "/",
+      },
+      {
+        onSuccess: () => {
+          setPending(false);
+        },
+        onError: ({ error }) => {
+          setPending(false);
+          setError(error.message);
+        },
+      }
+    );
+  };
 
   return (
     <div className="flex flex-col gap-6">
@@ -138,20 +158,22 @@ export const SignInView = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <Button
+                    disabled={pending}
+                    onClick={() => onSocial("google")}
                     variant="outline"
                     type="button"
                     className="w-full"
-                    disabled={pending}
                   >
-                    Google
+                    <FaGoogle />
                   </Button>
                   <Button
+                    disabled={pending}
+                    onClick={() => onSocial("github")}
                     variant="outline"
                     type="button"
                     className="w-full"
-                    disabled={pending}
                   >
-                    Github
+                    <FaGithub />
                   </Button>
                 </div>
                 <div className="text-center text-sm">

--- a/src/modules/auth/ui/views/sign-up-view.tsx
+++ b/src/modules/auth/ui/views/sign-up-view.tsx
@@ -7,12 +7,12 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { OctagonAlertIcon } from "lucide-react";
+import { FaGithub, FaGoogle } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertTitle } from "@/components/ui/alert";
-import { useRouter } from "next/navigation";
 
 import {
   Form,
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/form";
 import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
 
 const formSchema = z
   .object({
@@ -59,6 +60,27 @@ export const SignUpView = () => {
       confirmPassword: "",
     },
   });
+
+  const onSocial = (provider: "github" | "google") => {
+    setError(null);
+    setPending(true);
+
+    authClient.signIn.social(
+      {
+        provider: provider,
+        callbackURL: "/",
+      },
+      {
+        onSuccess: () => {
+          setPending(false);
+        },
+        onError: ({ error }) => {
+          setPending(false);
+          setError(error.message);
+        },
+      }
+    );
+  };
 
   function onSubmit(values: z.infer<typeof formSchema>) {
     setError(null);
@@ -189,20 +211,22 @@ export const SignUpView = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <Button
+                    disabled={pending}
+                    onClick={() => onSocial("google")}
                     variant="outline"
                     type="button"
                     className="w-full"
-                    disabled={pending}
                   >
-                    Google
+                    <FaGoogle />
                   </Button>
                   <Button
+                    disabled={pending}
+                    onClick={() => onSocial("github")}
                     variant="outline"
                     type="button"
                     className="w-full"
-                    disabled={pending}
                   >
-                    Github
+                    <FaGithub />
                   </Button>
                 </div>
                 <div className="text-center text-sm">

--- a/src/modules/home/ui/views/home-view.tsx
+++ b/src/modules/home/ui/views/home-view.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { authClient } from "@/lib/auth-client";
+import { useRouter } from "next/navigation";
+
+export const HomeView = () => {
+  const router = useRouter();
+  const { data: session } = authClient.useSession();
+
+  if (!session) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="flex flex-col p-4">
+      <p>Logged in as {session.user.name}</p>
+      <Button
+        onClick={() =>
+          authClient.signOut({
+            fetchOptions: {
+              onSuccess: () => {
+                router.push("/sign-in");
+              },
+            },
+          })
+        }
+      >
+        Sign Out
+      </Button>
+    </div>
+  );
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds GitHub and Google sign-in and server-side auth guards. Users can log in with socials, get redirected appropriately, and the home route is protected.

- **New Features**
  - Enabled socialProviders in auth for GitHub and Google (uses env vars).
  - Added social sign-in buttons with icons on Sign In/Up; uses callbackURL “/” and handles pending/errors.
  - Added server-side session checks on Sign In/Up pages; redirect to “/” if already authenticated.
  - Protected “/” with a server-side session check; redirect unauthenticated users to “/sign-in”.
  - Introduced HomeView with session display and Sign Out that routes back to “/sign-in”.

- **Dependencies**
  - Added react-icons.

<!-- End of auto-generated description by cubic. -->

