### PR TITLE
10: Agents Form

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,3 +1,4 @@
+import { AgentsListHeader } from "@/modules/agents/ui/components/agents-list-header";
 import {
   AgentsView,
   AgentsViewError,
@@ -7,18 +8,32 @@ import { getQueryClient, trpc } from "@/trpc/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 
-export default function AgentsPage() {
+export default async function AgentsPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return redirect("/sign-in");
+  }
+
   const queryClient = getQueryClient();
   void queryClient.prefetchQuery(trpc.agents.getMany.queryOptions());
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <Suspense fallback={<AgentsViewLoading />}>
-        <ErrorBoundary fallback={<AgentsViewError />}>
-          <AgentsView />
-        </ErrorBoundary>
-      </Suspense>
-    </HydrationBoundary>
+    <>
+      <AgentsListHeader />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<AgentsViewLoading />}>
+          <ErrorBoundary fallback={<AgentsViewError />}>
+            <AgentsView />
+          </ErrorBoundary>
+        </Suspense>
+      </HydrationBoundary>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
 import { TRPCReactProvider } from "@/trpc/client";
+import { Toaster } from "@/components/ui/sonner";
+import "./globals.css";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -20,7 +21,10 @@ export default function RootLayout({
   return (
     <TRPCReactProvider>
       <html lang="en">
-        <body className={`${inter.className} antialiased`}>{children}</body>
+        <body className={`${inter.className} antialiased`}>
+          <Toaster />
+          {children}
+        </body>
       </html>
     </TRPCReactProvider>
   );

--- a/src/modules/agents/schemas.ts
+++ b/src/modules/agents/schemas.ts
@@ -1,0 +1,6 @@
+import { z } from "zod";
+
+export const agentsInsertSchema = z.object({
+  name: z.string().min(1, { message: "Name is required" }),
+  instructions: z.string().min(1, { message: "Instructions are required" }),
+});

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -1,11 +1,39 @@
+import z from "zod";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
-import { baseProcedure, createTRPCRouter } from "@/trpc/init";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { agentsInsertSchema } from "../schemas";
+import { eq } from "drizzle-orm";
 
 export const agentsRouter = createTRPCRouter({
-  getMany: baseProcedure.query(async () => {
+  getOne: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      const [existingAgent] = await db
+        .select()
+        .from(agents)
+        .where(eq(agents.id, input.id));
+
+      return existingAgent;
+    }),
+  getMany: protectedProcedure.query(async () => {
     const data = await db.select().from(agents);
 
     return data;
   }),
+  create: protectedProcedure
+    .input(agentsInsertSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { auth } = ctx;
+
+      const [createdAgent] = await db
+        .insert(agents)
+        .values({
+          ...input,
+          userId: auth.user.id,
+        })
+        .returning();
+
+      return createdAgent;
+    }),
 });

--- a/src/modules/agents/types.ts
+++ b/src/modules/agents/types.ts
@@ -1,0 +1,5 @@
+import { inferRouterOutputs } from "@trpc/server";
+
+import type { AppRouter } from "@/trpc/routers/_app";
+
+export type AgentGetOne = inferRouterOutputs<AppRouter>["agents"]["getOne"];

--- a/src/modules/agents/ui/components/agent-form.tsx
+++ b/src/modules/agents/ui/components/agent-form.tsx
@@ -1,0 +1,131 @@
+import z from "zod";
+import { toast } from "sonner";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
+import { AgentGetOne } from "../../types";
+import { agentsInsertSchema } from "../../schemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+
+import { GeneratedAvatar } from "@/components/generated-avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+
+interface AgentFormProps {
+  onSuccess: () => void;
+  onCancel: () => void;
+  initialValues?: AgentGetOne;
+}
+export const AgentForm = ({
+  onSuccess,
+  onCancel,
+  initialValues,
+}: AgentFormProps) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const createAgent = useMutation(
+    trpc.agents.create.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(trpc.agents.getMany.queryOptions());
+
+        if (initialValues?.id) {
+          await queryClient.invalidateQueries(
+            trpc.agents.getOne.queryOptions({ id: initialValues.id })
+          );
+        }
+
+        onSuccess?.();
+      },
+      onError: (error) => {
+        toast.error(error.message);
+
+        // TODO: Check if error code is "FORBIDDEN", redirect to /upgrade
+      },
+    })
+  );
+
+  const form = useForm<z.infer<typeof agentsInsertSchema>>({
+    resolver: zodResolver(agentsInsertSchema),
+    defaultValues: {
+      name: initialValues?.name ?? "",
+      instructions: initialValues?.instructions ?? "",
+    },
+  });
+
+  const isEdit = !!initialValues?.id;
+  const isPending = createAgent.isPending;
+
+  function onSubmit(values: z.infer<typeof agentsInsertSchema>) {
+    if (isEdit) {
+      console.log("TODO: update agent");
+    } else {
+      createAgent.mutate(values);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <GeneratedAvatar
+          seed={form.watch("name")}
+          variant="botttsNeutral"
+          className="border size-16"
+        />
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input placeholder="e.g. Agent X" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="instructions"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Instructions</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="e.g. You are a helpful math assistant that can answer questions and help with assignments."
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <div className="flex justify-between gap-2">
+          {onCancel && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onCancel()}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+          )}
+          <Button type="submit" disabled={isPending}>
+            {isEdit ? "Update" : "Create"}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/src/modules/agents/ui/components/agents-list-header.tsx
+++ b/src/modules/agents/ui/components/agents-list-header.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "lucide-react";
+import { NewAgentDialog } from "./new-agent-dialog";
+import { useState } from "react";
+
+export const AgentsListHeader = () => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <NewAgentDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
+      <div className="py-4 px-4 md:px-8 flex flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h5 className="text-xl font-medium">My Agents</h5>
+          <Button onClick={() => setIsDialogOpen(true)}>
+            <PlusIcon className="size-4" />
+            New Agent
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/src/modules/agents/ui/components/new-agent-dialog.tsx
+++ b/src/modules/agents/ui/components/new-agent-dialog.tsx
@@ -1,0 +1,23 @@
+import { ResponsiveDialog } from "@/components/responsive-dialog";
+import { AgentForm } from "./agent-form";
+
+interface NewAgentDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const NewAgentDialog = ({ open, onOpenChange }: NewAgentDialogProps) => {
+  return (
+    <ResponsiveDialog
+      title="New Agent"
+      description="Create a new agent"
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <AgentForm
+        onSuccess={() => onOpenChange(false)}
+        onCancel={() => onOpenChange(false)}
+      />
+    </ResponsiveDialog>
+  );
+};

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,4 +1,6 @@
-import { initTRPC } from "@trpc/server";
+import { auth } from "@/lib/auth";
+import { initTRPC, TRPCError } from "@trpc/server";
+import { headers } from "next/headers";
 import { cache } from "react";
 export const createTRPCContext = cache(async () => {
   /**
@@ -20,3 +22,19 @@ const t = initTRPC.create({
 export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
 export const baseProcedure = t.procedure;
+export const protectedProcedure = baseProcedure.use(async ({ ctx, next }) => {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new TRPCError({ code: "UNAUTHORIZED", message: "Not authenticated" });
+  }
+
+  return next({
+    ctx: {
+      ...ctx,
+      auth: session,
+    },
+  });
+});


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add an authenticated create-agent flow with a new Agents form, dialog, and header. Protect agent routes with TRPC middleware, add validation, and redirect unauthenticated users to sign in.

- New Features
  - Agents page header with “New Agent” button and dialog.
  - Agent form with name/instructions, Zod validation, and avatar preview.
  - Create agent mutation + list/detail cache invalidation and toast errors.
  - Sign-in redirect on the Agents page.
  - Toaster added app-wide for notifications.

- Refactors
  - TRPC: added protectedProcedure with auth context; agents.getMany now requires auth; added agents.getOne and agents.create.
  - Shared Zod schema for server/client (agentsInsertSchema) and AgentGetOne type.

<!-- End of auto-generated description by cubic. -->

