### PR TITLE
11: Agents Data Table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.85.5",
+        "@tanstack/react-table": "^8.21.3",
         "@trpc/client": "^11.5.0",
         "@trpc/server": "^11.5.0",
         "@trpc/tanstack-react-query": "^11.5.0",
@@ -4190,6 +4191,39 @@
       },
       "peerDependencies": {
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@trpc/client": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.85.5",
+    "@tanstack/react-table": "^8.21.3",
     "@trpc/client": "^11.5.0",
     "@trpc/server": "^11.5.0",
     "@trpc/tanstack-react-query": "^11.5.0",

--- a/public/cancelled.svg
+++ b/public/cancelled.svg
@@ -1,0 +1,48 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Cancelled Icon (Circle with X inside) -->
+<circle cx="37" cy="62" r="8" fill="#EDF3F3"/>
+<path d="M33.5 58.5L40.5 65.5" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M40.5 58.5L33.5 65.5" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/public/empty.svg
+++ b/public/empty.svg
@@ -1,0 +1,40 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/public/processing.svg
+++ b/public/processing.svg
@@ -1,0 +1,46 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Premium Centered Checkmark -->
+<path d="M32 62L36 66L43 57" stroke="#B0B3B2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/public/upcoming.svg
+++ b/public/upcoming.svg
@@ -1,0 +1,47 @@
+<svg width="166" height="135" viewBox="12 0 166 135" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="94.5" cy="67.5" r="59.5" fill="#F5F6F6"/>
+<g filter="url(#filter0_d)">
+  <rect x="22" y="26" width="145" height="72" rx="6" fill="white"/>
+  <rect x="22.25" y="26.25" width="144.5" height="71.5" rx="5.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+<g filter="url(#filter1_dd)">
+  <rect x="12" y="37" width="166" height="50" rx="8" fill="white"/>
+  <rect x="12.25" y="37.25" width="165.5" height="49.5" rx="7.75" stroke="#E9F7F0" stroke-width="0.5"/>
+</g>
+
+<!-- Light gray background box -->
+<rect x="20" y="45" width="34" height="34" rx="6" fill="#F5F6F6"/>
+
+<!-- Perfectly Centered Video Camera Icon -->
+<rect x="28.5" y="56" width="13" height="10" rx="2" fill="#B0B3B2"/>
+<path d="M41.5 58L45.5 56V66L41.5 64V58Z" fill="#B0B3B2"/>
+
+<!-- Lines -->
+<rect x="63" y="49" width="72" height="4" rx="2" fill="#17A34A"/>
+<rect x="63" y="61" width="64" height="4" rx="2" fill="#D5F2E0"/>
+<rect x="63" y="73" width="94" height="4" rx="2" fill="#E9F7F0"/>
+
+<defs>
+  <filter id="filter0_d" x="20.125" y="25.0625" width="148.75" height="75.75" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feGaussianBlur stdDeviation="1"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.04 0"/>
+    <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+  </filter>
+  <filter id="filter1_dd" x="0" y="37" width="190" height="73" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+    <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+    <feMorphology radius="2" operator="erode" in="SourceAlpha" result="effect1_dropShadow"/>
+    <feOffset dy="4"/>
+    <feGaussianBlur stdDeviation="3"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.05 0"/>
+    <feBlend mode="normal" in2="effect1_dropShadow" result="effect1_dropShadow"/>
+    <feMorphology radius="4" operator="erode" in="SourceAlpha" result="effect2_dropShadow"/>
+    <feOffset dy="12"/>
+    <feGaussianBlur stdDeviation="8"/>
+    <feColorMatrix type="matrix" values="0 0 0 0 0.1 0 0 0 0 0.15 0 0 0 0 0.14 0 0 0 0.07 0"/>
+    <feBlend mode="normal" in2="effect2_dropShadow" result="effect2_dropShadow"/>
+    <feBlend mode="normal" in="SourceGraphic" in2="effect2_dropShadow" result="shape"/>
+  </filter>
+</defs>
+</svg>

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,23 @@
+import Image from "next/image";
+
+interface Props {
+  title: string;
+  description: string;
+  image?: string;
+}
+
+export const EmptyState = ({
+  title,
+  description,
+  image = "/empty.svg",
+}: Props) => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <Image src={image} alt="Empty" width={240} height={240} />
+      <div className="flex flex-col gap-y-6 max-w-md mx-auto text-center">
+        <h6 className="text-lg font-medium">{title}</h6>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -3,14 +3,18 @@ import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { agentsInsertSchema } from "../schemas";
-import { eq } from "drizzle-orm";
+import { eq, getTableColumns, sql } from "drizzle-orm";
 
 export const agentsRouter = createTRPCRouter({
   getOne: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input }) => {
       const [existingAgent] = await db
-        .select()
+        .select({
+          ...getTableColumns(agents),
+          // TODO: Change to actual count
+          meetingCount: sql<number>`5`,
+        })
         .from(agents)
         .where(eq(agents.id, input.id));
 

--- a/src/modules/agents/ui/components/columns.tsx
+++ b/src/modules/agents/ui/components/columns.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { AgentGetOne } from "../../types";
+import { GeneratedAvatar } from "@/components/generated-avatar";
+import { CornerDownRightIcon, VideoIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export const columns: ColumnDef<AgentGetOne>[] = [
+  {
+    accessorKey: "name",
+    header: "Agent Name",
+    cell: ({ row }) => (
+      <div className="flex flex-col gap-y-1">
+        <div className="flex items-center gap-x-2">
+          <GeneratedAvatar
+            variant="botttsNeutral"
+            seed={row.original.name}
+            className="size-6"
+          />
+          <span className="font-semibold capitalize">{row.original.name}</span>
+        </div>
+        <div className="flex items-center gap-x-2">
+          <CornerDownRightIcon className="size-3 text-muted-foreground" />
+          <span className="text-sm text-muted-foreground max-w-[200px] truncate capitalize">
+            {row.original.instructions}
+          </span>
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "meetingCount",
+    header: "Meetings",
+    cell: () => (
+      <Badge
+        variant="outline"
+        className="flex items-center gap-x-2 [&>svg]:size-4"
+      >
+        <VideoIcon className="text-blue-700" />5 meetings
+      </Badge>
+    ),
+  },
+];

--- a/src/modules/agents/ui/components/data-table.tsx
+++ b/src/modules/agents/ui/components/data-table.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  onRowClick?: (row: TData) => void;
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  onRowClick,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="overflow-hidden rounded-lg border bg-background">
+      <Table>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                onClick={() => onRowClick?.(row.original)}
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+                className="cursor-pointer"
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id} className="text-sm p-4">
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="h-19 text-center text-muted-foreground"
+              >
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -4,12 +4,25 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTRPC } from "@/trpc/client";
 import { LoadingState } from "@/components/loading-state";
 import { ErrorState } from "@/components/error-state";
+import { EmptyState } from "@/components/empty-state";
+import { columns } from "../components/columns";
+import { DataTable } from "../components/data-table";
 
 export const AgentsView = () => {
   const trpc = useTRPC();
   const { data } = useSuspenseQuery(trpc.agents.getMany.queryOptions());
 
-  return <div>{JSON.stringify(data, null, 2)}</div>;
+  return (
+    <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
+      <DataTable columns={columns} data={data} />
+      {data.length === 0 && (
+        <EmptyState
+          title="Create your first agent"
+          description="Create an agent to join your meetings. Each agent will follow your instructions and can interact with participants during the call."
+        />
+      )}
+    </div>
+  );
 };
 
 export const AgentsViewLoading = () => {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the Agents data table with avatars, instruction preview, and a meetings badge, plus a friendly empty state when no agents exist. Updates the Agents view to render the new table.

- New Features
  - Generic DataTable component to render agent rows.
  - Columns show avatar + name, truncated instructions, and a “5 meetings” badge with icon.
  - EmptyState component with new SVGs; shown when the agents list is empty.
  - Server: agents.getOne now returns meetingCount (temporary placeholder set to 5).

- Dependencies
  - Added @tanstack/react-table.

<!-- End of auto-generated description by cubic. -->

