### PR TITLE
12: Agents Filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "nanoid": "^5.1.5",
         "next": "15.5.2",
         "next-themes": "^0.4.6",
+        "nuqs": "^2.5.2",
         "react": "19.1.0",
         "react-day-picker": "^9.9.0",
         "react-dom": "19.1.0",
@@ -3875,6 +3876,12 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -8444,6 +8451,43 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/nuqs": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.5.2.tgz",
+      "integrity": "sha512-vzKeoYlMRmNYPWECdn53Nmh/jM+r/iSezEin342EVXPogT6KzALwdnYbZxASE5vTdXRUtOymtPkgsarLipKetg==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/franky47"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">=2",
+        "@tanstack/react-router": "^1",
+        "next": ">=14.2.0",
+        "react": ">=18.2.0 || ^19.0.0-0",
+        "react-router": "^6 || ^7",
+        "react-router-dom": "^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "nanoid": "^5.1.5",
     "next": "15.5.2",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.5.2",
     "react": "19.1.0",
     "react-day-picker": "^9.9.0",
     "react-dom": "19.1.0",

--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -11,8 +11,16 @@ import { ErrorBoundary } from "react-error-boundary";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import type { SearchParams } from "nuqs/server";
+import { loadSearchParams } from "@/modules/agents/params";
 
-export default async function AgentsPage() {
+interface AgentsPageProps {
+  searchParams: Promise<SearchParams>;
+}
+
+export default async function AgentsPage({ searchParams }: AgentsPageProps) {
+  const filters = await loadSearchParams(searchParams);
+
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -22,7 +30,9 @@ export default async function AgentsPage() {
   }
 
   const queryClient = getQueryClient();
-  void queryClient.prefetchQuery(trpc.agents.getMany.queryOptions());
+  void queryClient.prefetchQuery(
+    trpc.agents.getMany.queryOptions({ ...filters })
+  );
 
   return (
     <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { TRPCReactProvider } from "@/trpc/client";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
@@ -19,13 +20,15 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <TRPCReactProvider>
-      <html lang="en">
-        <body className={`${inter.className} antialiased`}>
-          <Toaster />
-          {children}
-        </body>
-      </html>
-    </TRPCReactProvider>
+    <NuqsAdapter>
+      <TRPCReactProvider>
+        <html lang="en">
+          <body className={`${inter.className} antialiased`}>
+            <Toaster />
+            {children}
+          </body>
+        </html>
+      </TRPCReactProvider>
+    </NuqsAdapter>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 10;
+export const MAX_PAGE_SIZE = 100;
+export const MIN_PAGE_SIZE = 1;

--- a/src/modules/agents/hooks/use-agents-filters.ts
+++ b/src/modules/agents/hooks/use-agents-filters.ts
@@ -1,0 +1,12 @@
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+
+import { DEFAULT_PAGE } from "@/constants";
+
+export const useAgentsFilters = () => {
+  return useQueryStates({
+    search: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+    page: parseAsInteger
+      .withDefault(DEFAULT_PAGE)
+      .withOptions({ clearOnDefault: true }),
+  });
+};

--- a/src/modules/agents/params.ts
+++ b/src/modules/agents/params.ts
@@ -1,0 +1,12 @@
+import { createLoader, parseAsInteger, parseAsString } from "nuqs/server";
+
+import { DEFAULT_PAGE } from "@/constants";
+
+export const filtersSearchParams = {
+  search: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+  page: parseAsInteger
+    .withDefault(DEFAULT_PAGE)
+    .withOptions({ clearOnDefault: true }),
+};
+
+export const loadSearchParams = createLoader(filtersSearchParams);

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -3,7 +3,13 @@ import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
 import { agentsInsertSchema } from "../schemas";
-import { eq, getTableColumns, sql } from "drizzle-orm";
+import { and, count, desc, eq, getTableColumns, ilike, sql } from "drizzle-orm";
+import {
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+} from "@/constants";
 
 export const agentsRouter = createTRPCRouter({
   getOne: protectedProcedure
@@ -20,11 +26,53 @@ export const agentsRouter = createTRPCRouter({
 
       return existingAgent;
     }),
-  getMany: protectedProcedure.query(async () => {
-    const data = await db.select().from(agents);
+  getMany: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().default(DEFAULT_PAGE),
+        pageSize: z
+          .number()
+          .min(MIN_PAGE_SIZE)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE),
+        search: z.string().nullish(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { page, pageSize, search } = input;
+      const { auth } = ctx;
 
-    return data;
-  }),
+      const data = await db
+        .select({
+          ...getTableColumns(agents),
+          // TODO: Change to actual count
+          meetingCount: sql<number>`5`,
+        })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.userId, auth.user.id),
+            search ? ilike(agents.name, `%${search}%`) : undefined
+          )
+        )
+        .orderBy(desc(agents.createdAt), desc(agents.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize);
+
+      const [total] = await db
+        .select({ count: count() })
+        .from(agents)
+        .where(
+          and(
+            eq(agents.userId, auth.user.id),
+            search ? ilike(agents.name, `%${search}%`) : undefined
+          )
+        );
+
+      const totalPages = Math.ceil(total.count / pageSize);
+
+      return { items: data, total: total.count, totalPages };
+    }),
   create: protectedProcedure
     .input(agentsInsertSchema)
     .mutation(async ({ input, ctx }) => {

--- a/src/modules/agents/ui/components/agent-form.tsx
+++ b/src/modules/agents/ui/components/agent-form.tsx
@@ -36,7 +36,9 @@ export const AgentForm = ({
   const createAgent = useMutation(
     trpc.agents.create.mutationOptions({
       onSuccess: async () => {
-        await queryClient.invalidateQueries(trpc.agents.getMany.queryOptions());
+        await queryClient.invalidateQueries(
+          trpc.agents.getMany.queryOptions({})
+        );
 
         if (initialValues?.id) {
           await queryClient.invalidateQueries(

--- a/src/modules/agents/ui/components/agents-list-header.tsx
+++ b/src/modules/agents/ui/components/agents-list-header.tsx
@@ -1,12 +1,22 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, XIcon } from "lucide-react";
 import { NewAgentDialog } from "./new-agent-dialog";
 import { useState } from "react";
+import { useAgentsFilters } from "../../hooks/use-agents-filters";
+import { AgentsSearchFilter } from "./agents-search-filter";
+import { DEFAULT_PAGE } from "@/constants";
 
 export const AgentsListHeader = () => {
+  const [filters, setFilters] = useAgentsFilters();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const isAnyFilterModified = !!filters.search;
+
+  const onClearFilters = () => {
+    setFilters({ search: "", page: DEFAULT_PAGE });
+  };
 
   return (
     <>
@@ -18,6 +28,15 @@ export const AgentsListHeader = () => {
             <PlusIcon className="size-4" />
             New Agent
           </Button>
+        </div>
+        <div className="flex items-center gap-x-2 p-1">
+          <AgentsSearchFilter />
+          {isAnyFilterModified && (
+            <Button variant="outline" onClick={onClearFilters}>
+              <XIcon className="size-4" />
+              Clear Filters
+            </Button>
+          )}
         </div>
       </div>
     </>

--- a/src/modules/agents/ui/components/agents-search-filter.tsx
+++ b/src/modules/agents/ui/components/agents-search-filter.tsx
@@ -1,0 +1,18 @@
+import { Input } from "@/components/ui/input";
+import { useAgentsFilters } from "../../hooks/use-agents-filters";
+import { SearchIcon } from "lucide-react";
+
+export const AgentsSearchFilter = () => {
+  const [filters, setFilters] = useAgentsFilters();
+  return (
+    <div className="relative">
+      <Input
+        placeholder="Filter by name"
+        className="h-9 bg-white w-[200px] pl-7"
+        value={filters.search}
+        onChange={(e) => setFilters({ search: e.target.value })}
+      />
+      <SearchIcon className="size-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+    </div>
+  );
+};

--- a/src/modules/agents/ui/components/columns.tsx
+++ b/src/modules/agents/ui/components/columns.tsx
@@ -32,12 +32,14 @@ export const columns: ColumnDef<AgentGetOne>[] = [
   {
     accessorKey: "meetingCount",
     header: "Meetings",
-    cell: () => (
+    cell: ({ row }) => (
       <Badge
         variant="outline"
         className="flex items-center gap-x-2 [&>svg]:size-4"
       >
-        <VideoIcon className="text-blue-700" />5 meetings
+        <VideoIcon className="text-blue-700" />
+        {row.original.meetingCount}{" "}
+        {row.original.meetingCount === 1 ? "meeting" : "meetings"}
       </Badge>
     ),
   },

--- a/src/modules/agents/ui/components/data-pagination.tsx
+++ b/src/modules/agents/ui/components/data-pagination.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/button";
+import { Pagination } from "@/components/ui/pagination";
+
+interface DataPaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+export const DataPagination = ({
+  page,
+  totalPages,
+  onPageChange,
+}: DataPaginationProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex-1 text-sm text-muted-foreground">
+        Page {page} of {totalPages || 1}
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          disabled={page === 1}
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          Previous
+        </Button>
+        <Button
+          disabled={page === totalPages || totalPages === 0}
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -7,15 +7,28 @@ import { ErrorState } from "@/components/error-state";
 import { EmptyState } from "@/components/empty-state";
 import { columns } from "../components/columns";
 import { DataTable } from "../components/data-table";
+import { useAgentsFilters } from "../../hooks/use-agents-filters";
+import { DataPagination } from "../components/data-pagination";
 
 export const AgentsView = () => {
+  const [filters, setFilters] = useAgentsFilters();
+
   const trpc = useTRPC();
-  const { data } = useSuspenseQuery(trpc.agents.getMany.queryOptions());
+  const { data } = useSuspenseQuery(
+    trpc.agents.getMany.queryOptions({
+      ...filters,
+    })
+  );
 
   return (
     <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
-      <DataTable columns={columns} data={data} />
-      {data.length === 0 && (
+      <DataTable columns={columns} data={data.items} />
+      <DataPagination
+        page={filters.page}
+        totalPages={data.totalPages}
+        onPageChange={(page) => setFilters({ page })}
+      />
+      {data.items.length === 0 && (
         <EmptyState
           title="Create your first agent"
           description="Create an agent to join your meetings. Each agent will follow your instructions and can interact with participants during the call."


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Add URL-synced search and pagination to the Agents page, with server-side filtering and faster prefetching. Addresses Linear 12.

- New Features
  - Search by name and page are stored in the URL via nuqs (useAgentsFilters, loadSearchParams). Clear Filters resets search and page=1.
  - Added pagination UI (DataPagination) with defaults: page=1, pageSize=10.
  - Server: agents.getMany now accepts { page, pageSize, search }, filters by user, applies ilike on name, sorts by newest, and returns { items, total, totalPages }.
  - Agents page prefetch reads filters from URL for SSR; meeting count displays per row.
  - Updated query invalidation to match the new query signature.

- Dependencies
  - Added nuqs@2.5.2 and wrapped the app with NuqsAdapter.

<!-- End of auto-generated description by cubic. -->

