### PR TITLE
13: Agent Page

### DIFF
--- a/src/app/(dashboard)/agents/[agentId]/page.tsx
+++ b/src/app/(dashboard)/agents/[agentId]/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+import { getQueryClient, trpc } from "@/trpc/server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import AgentIdView, {
+  AgentIdViewError,
+  AgentIdViewLoading,
+} from "@/modules/agents/ui/views/agent-id-view";
+
+interface AgentPageProps {
+  params: Promise<{ agentId: string }>;
+}
+
+export default async function AgentPage({ params }: AgentPageProps) {
+  const { agentId } = await params;
+
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(
+    trpc.agents.getOne.queryOptions({ id: agentId })
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<AgentIdViewLoading />}>
+        <ErrorBoundary fallback={<AgentIdViewError />}>
+          <AgentIdView agentId={agentId} />
+        </ErrorBoundary>
+      </Suspense>
+    </HydrationBoundary>
+  );
+}

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -10,11 +10,12 @@ import {
   MAX_PAGE_SIZE,
   MIN_PAGE_SIZE,
 } from "@/constants";
+import { TRPCError } from "@trpc/server";
 
 export const agentsRouter = createTRPCRouter({
   getOne: protectedProcedure
     .input(z.object({ id: z.string() }))
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
       const [existingAgent] = await db
         .select({
           ...getTableColumns(agents),
@@ -22,8 +23,13 @@ export const agentsRouter = createTRPCRouter({
           meetingCount: sql<number>`5`,
         })
         .from(agents)
-        .where(eq(agents.id, input.id));
+        .where(
+          and(eq(agents.id, input.id), eq(agents.userId, ctx.auth.user.id))
+        );
 
+      if (!existingAgent) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Agent not found" });
+      }
       return existingAgent;
     }),
   getMany: protectedProcedure

--- a/src/modules/agents/ui/components/agent-id-view-header.tsx
+++ b/src/modules/agents/ui/components/agent-id-view-header.tsx
@@ -1,0 +1,68 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { MoreVerticalIcon, PencilIcon, TrashIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface AgentIdViewHeaderProps {
+  agentId: string;
+  agentName: string;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+export const AgentIdViewHeader = ({
+  agentId,
+  agentName,
+  onEdit,
+  onRemove,
+}: AgentIdViewHeaderProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild className="font-medium text-xl">
+              <Link href="/agents">My Agents</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator className="text-foreground text-xl font-medium [&>svg]:size-4" />
+          <BreadcrumbItem>
+            <BreadcrumbLink
+              asChild
+              className="font-medium text-xl text-foreground"
+            >
+              <Link href={`/agents/${agentId}`}>{agentName}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <MoreVerticalIcon />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onEdit}>
+            <PencilIcon className="size-4 text-black" /> Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onRemove}>
+            <TrashIcon className="size-4 text-black" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};

--- a/src/modules/agents/ui/views/agent-id-view.tsx
+++ b/src/modules/agents/ui/views/agent-id-view.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { VideoIcon } from "lucide-react";
+import { ErrorState } from "@/components/error-state";
+import { LoadingState } from "@/components/loading-state";
+import { useTRPC } from "@/trpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { AgentIdViewHeader } from "../components/agent-id-view-header";
+import { GeneratedAvatar } from "@/components/generated-avatar";
+import { Badge } from "@/components/ui/badge";
+
+interface AgentIdViewProps {
+  agentId: string;
+}
+
+export default function AgentIdView({ agentId }: AgentIdViewProps) {
+  const trpc = useTRPC();
+
+  const { data } = useSuspenseQuery(
+    trpc.agents.getOne.queryOptions({ id: agentId })
+  );
+
+  return (
+    <div className="flex-1 py-4 px-4 md:px-8 flex-col gap-y-4">
+      <AgentIdViewHeader
+        agentId={agentId}
+        agentName={data.name}
+        onEdit={() => {}}
+        onRemove={() => {}}
+      />
+      <div className="bg-white rounded-lg border">
+        <div className="px-4 py-5 gap-y-5 flex flex-col col-span-5">
+          <div className="flex items-center gap-x-3">
+            <GeneratedAvatar
+              seed={data.name}
+              variant="botttsNeutral"
+              className="size-10"
+            />
+            <h2 className="text-2xl font-medium">{data.name}</h2>
+          </div>
+          <Badge
+            variant="outline"
+            className="flex items-center gap-x-2 [&>svg]:size-4"
+          >
+            <VideoIcon className="size-4 text-blue-700" />
+            {data.meetingCount}{" "}
+            {data.meetingCount === 1 ? "meeting" : "meetings"}
+          </Badge>
+          <div className="flex flex-col gap-y-4">
+            <p className="text-lg font-medium">Instructions</p>
+            <p className="text-neutral-800">{data.instructions}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const AgentIdViewLoading = () => {
+  return (
+    <LoadingState
+      title="Loading agent"
+      description="This may take a few seconds"
+    />
+  );
+};
+
+export const AgentIdViewError = () => {
+  return (
+    <ErrorState
+      title="Error Loading Agent"
+      description="Please try again later"
+    />
+  );
+};

--- a/src/modules/agents/ui/views/agents-view.tsx
+++ b/src/modules/agents/ui/views/agents-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTRPC } from "@/trpc/client";
 import { LoadingState } from "@/components/loading-state";
@@ -11,6 +12,7 @@ import { useAgentsFilters } from "../../hooks/use-agents-filters";
 import { DataPagination } from "../components/data-pagination";
 
 export const AgentsView = () => {
+  const router = useRouter();
   const [filters, setFilters] = useAgentsFilters();
 
   const trpc = useTRPC();
@@ -22,7 +24,11 @@ export const AgentsView = () => {
 
   return (
     <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
-      <DataTable columns={columns} data={data.items} />
+      <DataTable
+        columns={columns}
+        data={data.items}
+        onRowClick={(row) => router.push(`/agents/${row.id}`)}
+      />
       <DataPagination
         page={filters.page}
         totalPages={data.totalPages}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds the Agent detail page with server-side prefetching and a clean detail view; users can now click an agent in the list to see its info. Also scopes the getOne API to the signed-in user and returns 404 when the agent isn’t found. Implements Linear #13.

- **New Features**
  - New route /agents/[agentId] with prefetch + hydration, Suspense, and error handling.
  - Agent detail view shows avatar, name, meeting count, and instructions with a breadcrumb header and action menu.
  - Agents table rows navigate to the detail page on click.

- **Bug Fixes**
  - agents.getOne now filters by userId and throws NOT_FOUND when missing.

<!-- End of auto-generated description by cubic. -->

