### PR TITLE
15: Meetings Setup

### DIFF
--- a/src/app/(dashboard)/meetings/[meetingId]/page.tsx
+++ b/src/app/(dashboard)/meetings/[meetingId]/page.tsx
@@ -1,0 +1,9 @@
+interface MeetingIdPageProps {
+  params: Promise<{ meetingId: string }>;
+}
+
+export default async function MeetingPage({ params }: MeetingIdPageProps) {
+  const { meetingId } = await params;
+
+  return <div>MeetingPage</div>;
+}

--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,0 +1,24 @@
+import {
+  MeetingsView,
+  MeetingsViewError,
+  MeetingsViewLoading,
+} from "@/modules/meetings/ui/views/meetings-view";
+import { getQueryClient, trpc } from "@/trpc/server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+export default function MeetingsPage() {
+  const queryClient = getQueryClient();
+  void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}));
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<MeetingsViewLoading />}>
+        <ErrorBoundary fallback={<MeetingsViewError />}>
+          <MeetingsView />
+        </ErrorBoundary>
+      </Suspense>
+    </HydrationBoundary>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { nanoid } from "nanoid";
-import { pgTable, text, timestamp, boolean } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, pgEnum } from "drizzle-orm/pg-core";
 
 export const user = pgTable("user", {
   id: text("id").primaryKey(),
@@ -70,6 +70,35 @@ export const agents = pgTable("agents", {
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
   instructions: text("instructions").notNull(),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});
+
+export const meetingsStatus = pgEnum("meetings_status", [
+  "upcoming",
+  "active",
+  "completed",
+  "processing",
+  "cancelled",
+]);
+
+export const meetings = pgTable("meetings", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => nanoid()),
+  name: text("name").notNull(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  agentId: text("agent_id")
+    .notNull()
+    .references(() => agents.id, { onDelete: "cascade" }),
+  status: meetingsStatus("status").notNull().default("upcoming"),
+  startedAt: timestamp("started_at"),
+  endedAt: timestamp("ended_at"),
+  transcriptUrl: text("transcript_url"),
+  recordingUrl: text("recording_url"),
+  summary: text("summary"),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -1,0 +1,80 @@
+import z from "zod";
+import { db } from "@/db";
+import { meetings } from "@/db/schema";
+import { createTRPCRouter, protectedProcedure } from "@/trpc/init";
+import { and, count, desc, eq, getTableColumns, ilike } from "drizzle-orm";
+import {
+  DEFAULT_PAGE,
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MIN_PAGE_SIZE,
+} from "@/constants";
+import { TRPCError } from "@trpc/server";
+
+export const meetingsRouter = createTRPCRouter({
+  getOne: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const [existingMeeting] = await db
+        .select({
+          ...getTableColumns(meetings),
+        })
+        .from(meetings)
+        .where(
+          and(eq(meetings.id, input.id), eq(meetings.userId, ctx.auth.user.id))
+        );
+
+      if (!existingMeeting) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Meeting not found",
+        });
+      }
+      return existingMeeting;
+    }),
+  getMany: protectedProcedure
+    .input(
+      z.object({
+        page: z.number().default(DEFAULT_PAGE),
+        pageSize: z
+          .number()
+          .min(MIN_PAGE_SIZE)
+          .max(MAX_PAGE_SIZE)
+          .default(DEFAULT_PAGE_SIZE),
+        search: z.string().nullish(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { page, pageSize, search } = input;
+      const { auth } = ctx;
+
+      const data = await db
+        .select({
+          ...getTableColumns(meetings),
+        })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, auth.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        )
+        .orderBy(desc(meetings.createdAt), desc(meetings.id))
+        .limit(pageSize)
+        .offset((page - 1) * pageSize);
+
+      const [total] = await db
+        .select({ count: count() })
+        .from(meetings)
+        .where(
+          and(
+            eq(meetings.userId, auth.user.id),
+            search ? ilike(meetings.name, `%${search}%`) : undefined
+          )
+        );
+
+      const totalPages = Math.ceil(total.count / pageSize);
+
+      return { items: data, total: total.count, totalPages };
+    }),
+});

--- a/src/modules/meetings/ui/views/meetings-view.tsx
+++ b/src/modules/meetings/ui/views/meetings-view.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { ErrorState } from "@/components/error-state";
+import { LoadingState } from "@/components/loading-state";
+import { useTRPC } from "@/trpc/client";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export const MeetingsView = () => {
+  const trpc = useTRPC();
+  const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}));
+
+  return <div>{JSON.stringify(data, null, 2)}</div>;
+};
+
+export const MeetingsViewLoading = () => {
+  return (
+    <LoadingState
+      title="Loading meetings"
+      description="This may take a few seconds"
+    />
+  );
+};
+
+export const MeetingsViewError = () => {
+  return (
+    <ErrorState
+      title="Error Loading Meetings"
+      description="Please try again later"
+    />
+  );
+};

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,9 +1,11 @@
-import { createTRPCRouter } from "../init";
-
 import { agentsRouter } from "@/modules/agents/server/procedures";
+import { meetingsRouter } from "@/modules/meetings/server/procedures";
+
+import { createTRPCRouter } from "../init";
 
 export const appRouter = createTRPCRouter({
   agents: agentsRouter,
+  meetings: meetingsRouter,
 });
 // export type definition of API
 export type AppRouter = typeof appRouter;


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Set up the Meetings feature end-to-end: database schema, protected tRPC APIs, and a hydrated Meetings page with loading/error states. Implements Meetings Setup (Linear #15) to enable listing user meetings and prepares the detail route.

- **New Features**
  - DB: meetings_status enum and meetings table with FKs to user and agents, status defaulting to upcoming, timestamps.
  - API: meetingsRouter with protected getOne and getMany (pagination, optional name search, user-scoped, sorted by createdAt); returns items/total/totalPages.
  - UI: /meetings page with React Query prefetch + hydration, Suspense/ErrorBoundary, and MeetingsView; added placeholder /meetings/[meetingId] route.
  - Wiring: registered meetings router in app tRPC router.

- **Migration**
  - Run database migrations to create the enum and meetings table.

<!-- End of auto-generated description by cubic. -->

