### PR TITLE
16: Meetings Form

### DIFF
--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -1,3 +1,5 @@
+import { auth } from "@/lib/auth";
+import { MeetingsListHeader } from "@/modules/meetings/ui/components/meetings-list-header";
 import {
   MeetingsView,
   MeetingsViewError,
@@ -5,20 +7,33 @@ import {
 } from "@/modules/meetings/ui/views/meetings-view";
 import { getQueryClient, trpc } from "@/trpc/server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
-export default function MeetingsPage() {
+export default async function MeetingsPage() {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return redirect("/sign-in");
+  }
+
   const queryClient = getQueryClient();
   void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}));
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <Suspense fallback={<MeetingsViewLoading />}>
-        <ErrorBoundary fallback={<MeetingsViewError />}>
-          <MeetingsView />
-        </ErrorBoundary>
-      </Suspense>
-    </HydrationBoundary>
+    <>
+      <MeetingsListHeader />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <Suspense fallback={<MeetingsViewLoading />}>
+          <ErrorBoundary fallback={<MeetingsViewError />}>
+            <MeetingsView />
+          </ErrorBoundary>
+        </Suspense>
+      </HydrationBoundary>
+    </>
   );
 }

--- a/src/components/command-select.tsx
+++ b/src/components/command-select.tsx
@@ -1,0 +1,82 @@
+import { ReactNode, useState } from "react";
+import { ChevronsUpDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandResponsiveDialog,
+} from "@/components/ui/command";
+
+interface CommandSelectProps {
+  options: Array<{
+    id: string;
+    value: string;
+    children: ReactNode;
+  }>;
+  onSelect: (value: string) => void;
+  onSearch?: (value: string) => void;
+  value: string;
+  placeholder?: string;
+  isSearchable?: boolean;
+  className?: string;
+}
+
+export const CommandSelect = ({
+  options,
+  onSelect,
+  onSearch,
+  value,
+  placeholder = "Select an option",
+  className,
+}: CommandSelectProps) => {
+  const [open, setOpen] = useState(false);
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        className={cn(
+          "h-9 justify-between font-normal px-2",
+          !selectedOption && "text-muted-foreground",
+          className
+        )}
+        onClick={() => setOpen(true)}
+      >
+        <div>{selectedOption?.children ?? placeholder}</div>
+        <ChevronsUpDownIcon className="size-4" />
+      </Button>
+      <CommandResponsiveDialog
+        shouldFilter={!onSearch}
+        open={open}
+        onOpenChange={setOpen}
+        modal={false}
+      >
+        <CommandInput placeholder="Search" onValueChange={onSearch} />
+        <CommandList>
+          <CommandEmpty>
+            <span className="text-muted-foreground text-sm">
+              No options found
+            </span>
+          </CommandEmpty>
+          {options.map((option) => (
+            <CommandItem
+              key={option.id}
+              onSelect={() => {
+                onSelect(option.value);
+                setOpen(false);
+              }}
+            >
+              {option.children}
+            </CommandItem>
+          ))}
+        </CommandList>
+      </CommandResponsiveDialog>
+    </>
+  );
+};

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -74,10 +74,12 @@ function CommandResponsiveDialog({
   children,
   className,
   showCloseButton = true,
+  shouldFilter = true,
   ...props
 }: React.ComponentProps<typeof Dialog> & {
   title?: string;
   description?: string;
+  shouldFilter?: boolean;
   className?: string;
   showCloseButton?: boolean;
 }) {
@@ -91,7 +93,10 @@ function CommandResponsiveDialog({
             <DrawerTitle>{title}</DrawerTitle>
             <DrawerDescription>{description}</DrawerDescription>
           </DrawerHeader>
-          <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          <Command
+            shouldFilter={shouldFilter}
+            className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+          >
             {children}
           </Command>
         </DrawerContent>
@@ -109,7 +114,10 @@ function CommandResponsiveDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          shouldFilter={shouldFilter}
+          className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>

--- a/src/modules/agents/server/procedures.ts
+++ b/src/modules/agents/server/procedures.ts
@@ -30,7 +30,6 @@ export const agentsRouter = createTRPCRouter({
 
       return updatedAgent;
     }),
-
   remove: protectedProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ input, ctx }) => {
@@ -45,6 +44,21 @@ export const agentsRouter = createTRPCRouter({
       }
 
       return removeAgent;
+    }),
+  create: protectedProcedure
+    .input(agentsInsertSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { auth } = ctx;
+
+      const [createdAgent] = await db
+        .insert(agents)
+        .values({
+          ...input,
+          userId: auth.user.id,
+        })
+        .returning();
+
+      return createdAgent;
     }),
   getOne: protectedProcedure
     .input(z.object({ id: z.string() }))
@@ -111,20 +125,5 @@ export const agentsRouter = createTRPCRouter({
       const totalPages = Math.ceil(total.count / pageSize);
 
       return { items: data, total: total.count, totalPages };
-    }),
-  create: protectedProcedure
-    .input(agentsInsertSchema)
-    .mutation(async ({ input, ctx }) => {
-      const { auth } = ctx;
-
-      const [createdAgent] = await db
-        .insert(agents)
-        .values({
-          ...input,
-          userId: auth.user.id,
-        })
-        .returning();
-
-      return createdAgent;
     }),
 });

--- a/src/modules/meetings/schemas.ts
+++ b/src/modules/meetings/schemas.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const meetingsInsertSchema = z.object({
+  name: z.string().min(1, { message: "Name is required" }),
+  agentId: z.string().min(1, { message: "Agent is required" }),
+});
+
+export const meetingsUpdateSchema = meetingsInsertSchema.extend({
+  id: z.string().min(1, { message: "ID is required" }),
+});

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -10,8 +10,45 @@ import {
   MIN_PAGE_SIZE,
 } from "@/constants";
 import { TRPCError } from "@trpc/server";
+import { meetingsInsertSchema, meetingsUpdateSchema } from "../schemas";
 
 export const meetingsRouter = createTRPCRouter({
+  update: protectedProcedure
+    .input(meetingsUpdateSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { auth } = ctx;
+
+      const [updatedMeeting] = await db
+        .update(meetings)
+        .set(input)
+        .where(
+          and(eq(meetings.id, input.id), eq(meetings.userId, auth.user.id))
+        )
+        .returning();
+
+      if (!updatedMeeting) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Agent not found" });
+      }
+
+      return updatedMeeting;
+    }),
+  create: protectedProcedure
+    .input(meetingsInsertSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { auth } = ctx;
+
+      const [createdMeeting] = await db
+        .insert(meetings)
+        .values({
+          ...input,
+          userId: auth.user.id,
+        })
+        .returning();
+
+      // TODO: Create Stream Call, Upsert Stream Users
+
+      return createdMeeting;
+    }),
   getOne: protectedProcedure
     .input(z.object({ id: z.string() }))
     .query(async ({ input, ctx }) => {

--- a/src/modules/meetings/types.ts
+++ b/src/modules/meetings/types.ts
@@ -1,0 +1,5 @@
+import { inferRouterOutputs } from "@trpc/server";
+
+import type { AppRouter } from "@/trpc/routers/_app";
+
+export type MeetingGetOne = inferRouterOutputs<AppRouter>["meetings"]["getOne"];

--- a/src/modules/meetings/ui/components/meeting-form.tsx
+++ b/src/modules/meetings/ui/components/meeting-form.tsx
@@ -1,0 +1,193 @@
+import z from "zod";
+import { toast } from "sonner";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTRPC } from "@/trpc/client";
+
+import { MeetingGetOne } from "../../types";
+import { meetingsInsertSchema } from "../../schemas";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { CommandSelect } from "@/components/command-select";
+import { GeneratedAvatar } from "@/components/generated-avatar";
+import { NewAgentDialog } from "@/modules/agents/ui/components/new-agent-dialog";
+
+interface MeetingFormProps {
+  onSuccess?: (id?: string) => void;
+  onCancel?: () => void;
+  initialValues?: MeetingGetOne;
+}
+export const MeetingForm = ({
+  onSuccess,
+  onCancel,
+  initialValues,
+}: MeetingFormProps) => {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+
+  const [openNewAgentDialog, setOpenNewAgentDialog] = useState(false);
+  const [agentSearch, setAgentSearch] = useState("");
+
+  const agents = useQuery(
+    trpc.agents.getMany.queryOptions({
+      pageSize: 100,
+      search: agentSearch,
+    })
+  );
+
+  const createMeeting = useMutation(
+    trpc.meetings.create.mutationOptions({
+      onSuccess: async (data) => {
+        await queryClient.invalidateQueries(
+          trpc.meetings.getMany.queryOptions({})
+        );
+
+        // TODO: Invalidate free tier usage
+
+        onSuccess?.(data.id);
+      },
+      onError: (error) => {
+        toast.error(error.message);
+
+        // TODO: Check if error code is "FORBIDDEN", redirect to /upgrade
+      },
+    })
+  );
+
+  const updateMeeting = useMutation(
+    trpc.meetings.update.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(
+          trpc.meetings.getMany.queryOptions({})
+        );
+
+        if (initialValues?.id) {
+          await queryClient.invalidateQueries(
+            trpc.meetings.getOne.queryOptions({ id: initialValues.id })
+          );
+        }
+        // TODO: Invalidate free tier usage
+        onSuccess?.();
+      },
+      onError: (error) => {
+        toast.error(error.message);
+
+        // TODO: Check if error code is "FORBIDDEN", redirect to /upgrade
+      },
+    })
+  );
+
+  const form = useForm<z.infer<typeof meetingsInsertSchema>>({
+    resolver: zodResolver(meetingsInsertSchema),
+    defaultValues: {
+      name: initialValues?.name ?? "",
+      agentId: initialValues?.agentId ?? "",
+    },
+  });
+
+  const isEdit = !!initialValues?.id;
+  const isPending = createMeeting.isPending || updateMeeting.isPending;
+
+  function onSubmit(values: z.infer<typeof meetingsInsertSchema>) {
+    if (isEdit) {
+      updateMeeting.mutate({ ...values, id: initialValues.id });
+    } else {
+      createMeeting.mutate(values);
+    }
+  }
+
+  return (
+    <>
+      <NewAgentDialog
+        open={openNewAgentDialog}
+        onOpenChange={setOpenNewAgentDialog}
+      />
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. Math Consultations" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="agentId"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Agent</FormLabel>
+                <FormControl>
+                  <CommandSelect
+                    options={(agents.data?.items ?? []).map((agent) => ({
+                      id: agent.id,
+                      value: agent.id,
+                      children: (
+                        <div className="flex items-center gap-x-2">
+                          <GeneratedAvatar
+                            seed={agent.name}
+                            variant="botttsNeutral"
+                            className="border size-6"
+                          />
+                          <span>{agent.name}</span>
+                        </div>
+                      ),
+                    }))}
+                    value={field.value}
+                    onSelect={field.onChange}
+                    onSearch={setAgentSearch}
+                    placeholder="Select an agent"
+                  />
+                </FormControl>
+                <FormDescription>
+                  Not found what you&apos;re looking for?{" "}
+                  <Button
+                    type="button"
+                    variant="link"
+                    onClick={() => setOpenNewAgentDialog(true)}
+                  >
+                    Create a new agent
+                  </Button>
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex justify-between gap-2">
+            {onCancel && (
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onCancel()}
+                disabled={isPending}
+              >
+                Cancel
+              </Button>
+            )}
+            <Button type="submit" disabled={isPending}>
+              {isEdit ? "Update" : "Create"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </>
+  );
+};

--- a/src/modules/meetings/ui/components/meetings-list-header.tsx
+++ b/src/modules/meetings/ui/components/meetings-list-header.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "lucide-react";
+import { NewMeetingDialog } from "./new-meeting-dialog";
+
+export const MeetingsListHeader = () => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  return (
+    <>
+      <NewMeetingDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />
+      <div className="py-4 px-4 md:px-8 flex flex-col gap-y-4">
+        <div className="flex items-center justify-between">
+          <h5 className="text-xl font-medium">My Meetings</h5>
+          <Button onClick={() => setIsDialogOpen(true)}>
+            <PlusIcon className="size-4" />
+            New Meeting
+          </Button>
+        </div>
+        <div className="flex items-center gap-x-2 p-1">TODO: Filters</div>
+      </div>
+    </>
+  );
+};

--- a/src/modules/meetings/ui/components/new-meeting-dialog.tsx
+++ b/src/modules/meetings/ui/components/new-meeting-dialog.tsx
@@ -1,0 +1,32 @@
+import { ResponsiveDialog } from "@/components/responsive-dialog";
+import { MeetingForm } from "./meeting-form";
+import { useRouter } from "next/navigation";
+
+interface NewMeetingDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const NewMeetingDialog = ({
+  open,
+  onOpenChange,
+}: NewMeetingDialogProps) => {
+  const router = useRouter();
+
+  return (
+    <ResponsiveDialog
+      title="New Meeting"
+      description="Create a new meeting"
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <MeetingForm
+        onSuccess={(id) => {
+          onOpenChange(false);
+          router.push(`/meetings/${id}`);
+        }}
+        onCancel={() => onOpenChange}
+      />
+    </ResponsiveDialog>
+  );
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Implements the meetings creation flow with a new form and dialog, including a searchable Agent picker. Gates the Meetings page behind auth and wires up create/update APIs with cache invalidation (Linear #16).

- New Features
  - Meetings page: auth check with redirect to /sign-in, header with “New Meeting” button, and prefetch of meetings.
  - NewMeetingDialog: opens MeetingForm and routes to /meetings/:id on success.
  - MeetingForm: name and agent fields with zod validation; create and update mutations; invalidates meetings list and detail; error toasts; quick link to create a new agent.
  - CommandSelect: reusable, searchable command-style select with responsive dialog and external search support.
  - TRPC: meetings.create and meetings.update procedures with schemas; returns created/updated meeting.
  - UI: CommandResponsiveDialog now accepts shouldFilter to support external filtering.

<!-- End of auto-generated description by cubic. -->

