### PR TITLE
18: Meetings Filters

### DIFF
--- a/src/app/(dashboard)/meetings/page.tsx
+++ b/src/app/(dashboard)/meetings/page.tsx
@@ -11,8 +11,18 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+import type { SearchParams } from "nuqs/server";
+import { loadSearchParams } from "@/modules/meetings/params";
 
-export default async function MeetingsPage() {
+interface MeetingsPageProps {
+  searchParams: Promise<SearchParams>;
+}
+
+export default async function MeetingsPage({
+  searchParams,
+}: MeetingsPageProps) {
+  const filters = await loadSearchParams(searchParams);
+
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -22,7 +32,9 @@ export default async function MeetingsPage() {
   }
 
   const queryClient = getQueryClient();
-  void queryClient.prefetchQuery(trpc.meetings.getMany.queryOptions({}));
+  void queryClient.prefetchQuery(
+    trpc.meetings.getMany.queryOptions({ ...filters })
+  );
 
   return (
     <>

--- a/src/components/command-select.tsx
+++ b/src/components/command-select.tsx
@@ -36,6 +36,11 @@ export const CommandSelect = ({
   const [open, setOpen] = useState(false);
   const selectedOption = options.find((option) => option.value === value);
 
+  const handleClose = (open: boolean) => {
+    onSearch?.("");
+    setOpen(open);
+  };
+
   return (
     <>
       <Button
@@ -54,7 +59,7 @@ export const CommandSelect = ({
       <CommandResponsiveDialog
         shouldFilter={!onSearch}
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={handleClose}
         modal={false}
       >
         <CommandInput placeholder="Search" onValueChange={onSearch} />

--- a/src/components/data-pagination.tsx
+++ b/src/components/data-pagination.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@/components/ui/button";
+import { Pagination } from "@/components/ui/pagination";
+
+interface DataPaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+export const DataPagination = ({
+  page,
+  totalPages,
+  onPageChange,
+}: DataPaginationProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex-1 text-sm text-muted-foreground">
+        Page {page} of {totalPages || 1}
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <Button
+          disabled={page === 1}
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(Math.max(1, page - 1))}
+        >
+          Previous
+        </Button>
+        <Button
+          disabled={page === totalPages || totalPages === 0}
+          variant="outline"
+          size="sm"
+          onClick={() => onPageChange(Math.min(totalPages, page + 1))}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
+  "inline-flex items-center justify-center rounded-md border px-2 py-1 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
@@ -23,7 +23,7 @@ const badgeVariants = cva(
       variant: "default",
     },
   }
-)
+);
 
 function Badge({
   className,
@@ -32,7 +32,7 @@ function Badge({
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+  const Comp = asChild ? Slot : "span";
 
   return (
     <Comp
@@ -40,7 +40,7 @@ function Badge({
       className={cn(badgeVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/modules/meetings/hooks/use-meetings-filters.ts
+++ b/src/modules/meetings/hooks/use-meetings-filters.ts
@@ -1,0 +1,23 @@
+import {
+  parseAsInteger,
+  parseAsString,
+  parseAsStringEnum,
+  useQueryStates,
+} from "nuqs";
+
+import { DEFAULT_PAGE } from "@/constants";
+
+import { MeetingStatus } from "../types";
+
+export const useMeetingsFilters = () => {
+  return useQueryStates({
+    search: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+    page: parseAsInteger
+      .withDefault(DEFAULT_PAGE)
+      .withOptions({ clearOnDefault: true }),
+    agentId: parseAsString
+      .withDefault("")
+      .withOptions({ clearOnDefault: true }),
+    status: parseAsStringEnum(Object.values(MeetingStatus)),
+  });
+};

--- a/src/modules/meetings/params.ts
+++ b/src/modules/meetings/params.ts
@@ -1,0 +1,21 @@
+import {
+  createLoader,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringEnum,
+} from "nuqs/server";
+
+import { DEFAULT_PAGE } from "@/constants";
+
+import { MeetingStatus } from "./types";
+
+export const filtersSearchParams = {
+  search: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+  page: parseAsInteger
+    .withDefault(DEFAULT_PAGE)
+    .withOptions({ clearOnDefault: true }),
+  agentId: parseAsString.withDefault("").withOptions({ clearOnDefault: true }),
+  status: parseAsStringEnum(Object.values(MeetingStatus)),
+};
+
+export const loadSearchParams = createLoader(filtersSearchParams);

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -11,6 +11,7 @@ import {
 } from "@/constants";
 import { TRPCError } from "@trpc/server";
 import { meetingsInsertSchema, meetingsUpdateSchema } from "../schemas";
+import { MeetingStatus } from "../types";
 
 export const meetingsRouter = createTRPCRouter({
   update: protectedProcedure
@@ -79,10 +80,20 @@ export const meetingsRouter = createTRPCRouter({
           .max(MAX_PAGE_SIZE)
           .default(DEFAULT_PAGE_SIZE),
         search: z.string().nullish(),
+        agentId: z.string().nullish(),
+        status: z
+          .enum([
+            MeetingStatus.Upcoming,
+            MeetingStatus.Active,
+            MeetingStatus.Completed,
+            MeetingStatus.Cancelled,
+            MeetingStatus.Processing,
+          ])
+          .nullish(),
       })
     )
     .query(async ({ ctx, input }) => {
-      const { page, pageSize, search } = input;
+      const { page, pageSize, search, agentId, status } = input;
       const { auth } = ctx;
 
       const data = await db
@@ -98,7 +109,9 @@ export const meetingsRouter = createTRPCRouter({
         .where(
           and(
             eq(meetings.userId, auth.user.id),
-            search ? ilike(meetings.name, `%${search}%`) : undefined
+            search ? ilike(meetings.name, `%${search}%`) : undefined,
+            status ? eq(meetings.status, status) : undefined,
+            agentId ? eq(meetings.agentId, agentId) : undefined
           )
         )
         .orderBy(desc(meetings.createdAt), desc(meetings.id))
@@ -112,7 +125,9 @@ export const meetingsRouter = createTRPCRouter({
         .where(
           and(
             eq(meetings.userId, auth.user.id),
-            search ? ilike(meetings.name, `%${search}%`) : undefined
+            search ? ilike(meetings.name, `%${search}%`) : undefined,
+            status ? eq(meetings.status, status) : undefined,
+            agentId ? eq(meetings.agentId, agentId) : undefined
           )
         );
 

--- a/src/modules/meetings/types.ts
+++ b/src/modules/meetings/types.ts
@@ -5,3 +5,10 @@ import type { AppRouter } from "@/trpc/routers/_app";
 export type MeetingGetOne = inferRouterOutputs<AppRouter>["meetings"]["getOne"];
 export type MeetingGetMany =
   inferRouterOutputs<AppRouter>["meetings"]["getMany"]["items"];
+export enum MeetingStatus {
+  Upcoming = "upcoming",
+  Active = "active",
+  Completed = "completed",
+  Cancelled = "cancelled",
+  Processing = "processing",
+}

--- a/src/modules/meetings/ui/components/agent-id-filter.tsx
+++ b/src/modules/meetings/ui/components/agent-id-filter.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { useTRPC } from "@/trpc/client";
+import { CommandSelect } from "@/components/command-select";
+import { GeneratedAvatar } from "@/components/generated-avatar";
+
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+
+export const AgentIdFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters();
+
+  const trpc = useTRPC();
+
+  const [agentSearch, setAgentSearch] = useState("");
+  const { data } = useQuery(
+    trpc.agents.getMany.queryOptions({
+      pageSize: 100,
+      search: agentSearch,
+    })
+  );
+
+  return (
+    <CommandSelect
+      className="h-9"
+      placeholder="Agent"
+      options={(data?.items ?? []).map((agent) => ({
+        id: agent.id,
+        value: agent.id,
+        children: (
+          <div className="flex items-center gap-x-2">
+            <GeneratedAvatar
+              seed={agent.name}
+              variant="botttsNeutral"
+              className="size-4"
+            />
+            {agent.name}
+          </div>
+        ),
+      }))}
+      onSelect={(value) => setFilters({ agentId: value })}
+      onSearch={setAgentSearch}
+      value={filters.agentId ?? ""}
+    />
+  );
+};

--- a/src/modules/meetings/ui/components/meetings-list-header.tsx
+++ b/src/modules/meetings/ui/components/meetings-list-header.tsx
@@ -2,11 +2,25 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { PlusIcon } from "lucide-react";
+import { PlusIcon, XIcon } from "lucide-react";
 import { NewMeetingDialog } from "./new-meeting-dialog";
+import { MeetingsSearchFilter } from "./meetings-search-filter";
+import { StatusFilter } from "./status-filter";
+import { AgentIdFilter } from "./agent-id-filter";
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+import { DEFAULT_PAGE } from "@/constants";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 
 export const MeetingsListHeader = () => {
+  const [filters, setFilters] = useMeetingsFilters();
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const isAnyFilterModified =
+    !!filters.search || !!filters.status || !!filters.agentId;
+
+  const onClearFilters = () => {
+    setFilters({ search: "", status: null, agentId: "", page: DEFAULT_PAGE });
+  };
 
   return (
     <>
@@ -19,7 +33,20 @@ export const MeetingsListHeader = () => {
             New Meeting
           </Button>
         </div>
-        <div className="flex items-center gap-x-2 p-1">TODO: Filters</div>
+        <ScrollArea>
+          <div className="flex items-center gap-x-2 p-1">
+            <MeetingsSearchFilter />
+            <StatusFilter />
+            <AgentIdFilter />
+            {isAnyFilterModified && (
+              <Button variant="outline" onClick={onClearFilters}>
+                <XIcon className="size-4" />
+                Clear Filters
+              </Button>
+            )}
+          </div>
+          <ScrollBar orientation="horizontal" />
+        </ScrollArea>
       </div>
     </>
   );

--- a/src/modules/meetings/ui/components/meetings-search-filter.tsx
+++ b/src/modules/meetings/ui/components/meetings-search-filter.tsx
@@ -1,0 +1,18 @@
+import { Input } from "@/components/ui/input";
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+import { SearchIcon } from "lucide-react";
+
+export const MeetingsSearchFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters();
+  return (
+    <div className="relative">
+      <Input
+        placeholder="Filter by name"
+        className="h-9 bg-white w-[200px] pl-7"
+        value={filters.search}
+        onChange={(e) => setFilters({ search: e.target.value })}
+      />
+      <SearchIcon className="size-4 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+    </div>
+  );
+};

--- a/src/modules/meetings/ui/components/status-filter.tsx
+++ b/src/modules/meetings/ui/components/status-filter.tsx
@@ -1,0 +1,78 @@
+import {
+  CircleXIcon,
+  CircleCheckIcon,
+  ClockArrowUpIcon,
+  VideoIcon,
+  LoaderIcon,
+} from "lucide-react";
+
+import { CommandSelect } from "@/components/command-select";
+import { MeetingStatus } from "../../types";
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+
+const options = [
+  {
+    id: MeetingStatus.Upcoming,
+    value: MeetingStatus.Upcoming,
+    children: (
+      <div className="flex items-center gap-x-2 capitalize">
+        <ClockArrowUpIcon />
+        {MeetingStatus.Upcoming}
+      </div>
+    ),
+  },
+  {
+    id: MeetingStatus.Completed,
+    value: MeetingStatus.Completed,
+    children: (
+      <div className="flex items-center gap-x-2 capitalize">
+        <CircleCheckIcon />
+        {MeetingStatus.Completed}
+      </div>
+    ),
+  },
+  {
+    id: MeetingStatus.Active,
+    value: MeetingStatus.Active,
+    children: (
+      <div className="flex items-center gap-x-2 capitalize">
+        <VideoIcon />
+        {MeetingStatus.Active}
+      </div>
+    ),
+  },
+  {
+    id: MeetingStatus.Processing,
+    value: MeetingStatus.Processing,
+    children: (
+      <div className="flex items-center gap-x-2 capitalize">
+        <LoaderIcon />
+        {MeetingStatus.Processing}
+      </div>
+    ),
+  },
+  {
+    id: MeetingStatus.Cancelled,
+    value: MeetingStatus.Cancelled,
+    children: (
+      <div className="flex items-center gap-x-2 capitalize">
+        <CircleXIcon />
+        {MeetingStatus.Cancelled}
+      </div>
+    ),
+  },
+];
+
+export const StatusFilter = () => {
+  const [filters, setFilters] = useMeetingsFilters();
+
+  return (
+    <CommandSelect
+      placeholder="Status"
+      className="h-9"
+      options={options}
+      onSelect={(value) => setFilters({ status: value as MeetingStatus })}
+      value={filters.status ?? ""}
+    />
+  );
+};

--- a/src/modules/meetings/ui/views/meetings-view.tsx
+++ b/src/modules/meetings/ui/views/meetings-view.tsx
@@ -7,14 +7,32 @@ import { useTRPC } from "@/trpc/client";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { columns } from "../components/columns";
 import { EmptyState } from "@/components/empty-state";
+import { useRouter } from "next/navigation";
+import { useMeetingsFilters } from "../../hooks/use-meetings-filters";
+import { DataPagination } from "@/components/data-pagination";
 
 export const MeetingsView = () => {
+  const router = useRouter();
+  const [filters, setFilters] = useMeetingsFilters();
   const trpc = useTRPC();
-  const { data } = useSuspenseQuery(trpc.meetings.getMany.queryOptions({}));
+  const { data } = useSuspenseQuery(
+    trpc.meetings.getMany.queryOptions({
+      ...filters,
+    })
+  );
 
   return (
     <div className="flex-1 pb-4 px-4 md:px-8 flex flex-col gap-y-4">
-      <DataTable data={data.items} columns={columns} />
+      <DataTable
+        data={data.items}
+        columns={columns}
+        onRowClick={(row) => router.push(`/meetings/${row.id}`)}
+      />
+      <DataPagination
+        page={filters.page}
+        totalPages={data.totalPages}
+        onPageChange={(page) => setFilters({ page })}
+      />
       {data.items.length === 0 && (
         <EmptyState
           title="Create your first meeting"


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds searchable, status, and agent filters to Meetings with URL-synced state and paginated results. Updates API and SSR prefetch to honor filters for faster, accurate loads (Linear 18).

- **New Features**
  - Filters: search by name, status, and agent, plus a Clear Filters action.
  - URL state: nuqs-powered hooks and a server loader keep filters in the query string.
  - API: meetings.getMany now accepts search, status, and agentId; filters applied to list and count.
  - Prefetch: Meetings page prefetches using loaded filters.
  - Pagination: new DataPagination with page/totalPages; table rows navigate on click.
  - UX: CommandSelect clears its search when closed; minor Badge spacing tweak.

<!-- End of auto-generated description by cubic. -->

