### PR TITLE
19: Meeting Page

### DIFF
--- a/src/app/(dashboard)/meetings/[meetingId]/page.tsx
+++ b/src/app/(dashboard)/meetings/[meetingId]/page.tsx
@@ -1,3 +1,16 @@
+import { auth } from "@/lib/auth";
+import {
+  MeetingIdView,
+  MeetingIdViewError,
+  MeetingIdViewLoading,
+} from "@/modules/meetings/ui/views/meeting-id-view";
+import { getQueryClient, trpc } from "@/trpc/server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
 interface MeetingIdPageProps {
   params: Promise<{ meetingId: string }>;
 }
@@ -5,5 +18,28 @@ interface MeetingIdPageProps {
 export default async function MeetingPage({ params }: MeetingIdPageProps) {
   const { meetingId } = await params;
 
-  return <div>MeetingPage</div>;
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    return redirect("/sign-in");
+  }
+
+  const queryClient = getQueryClient();
+  void queryClient.prefetchQuery(
+    trpc.meetings.getOne.queryOptions({ id: meetingId })
+  );
+
+  // TODO: Prefetch `meetings.getTranscript`
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<MeetingIdViewLoading />}>
+        <ErrorBoundary fallback={<MeetingIdViewError />}>
+          <MeetingIdView meetingId={meetingId} />
+        </ErrorBoundary>
+      </Suspense>
+    </HydrationBoundary>
+  );
 }

--- a/src/modules/meetings/server/procedures.ts
+++ b/src/modules/meetings/server/procedures.ts
@@ -14,6 +14,24 @@ import { meetingsInsertSchema, meetingsUpdateSchema } from "../schemas";
 import { MeetingStatus } from "../types";
 
 export const meetingsRouter = createTRPCRouter({
+  remove: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const { auth } = ctx;
+
+      const [removedMeeting] = await db
+        .delete(meetings)
+        .where(
+          and(eq(meetings.id, input.id), eq(meetings.userId, auth.user.id))
+        )
+        .returning();
+
+      if (!removedMeeting) {
+        throw new TRPCError({ code: "NOT_FOUND", message: "Agent not found" });
+      }
+
+      return removedMeeting;
+    }),
   update: protectedProcedure
     .input(meetingsUpdateSchema)
     .mutation(async ({ input, ctx }) => {
@@ -56,8 +74,13 @@ export const meetingsRouter = createTRPCRouter({
       const [existingMeeting] = await db
         .select({
           ...getTableColumns(meetings),
+          agent: agents,
+          duration: sql<number>`EXTRACT(EPOCH FROM (ended_at - started_at))`.as(
+            "duration"
+          ),
         })
         .from(meetings)
+        .innerJoin(agents, eq(meetings.agentId, agents.id))
         .where(
           and(eq(meetings.id, input.id), eq(meetings.userId, ctx.auth.user.id))
         );

--- a/src/modules/meetings/ui/components/meeting-id-view-header.tsx
+++ b/src/modules/meetings/ui/components/meeting-id-view-header.tsx
@@ -1,0 +1,68 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { MoreVerticalIcon, PencilIcon, TrashIcon } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface AgentIdViewHeaderProps {
+  meetingId: string;
+  meetingName: string;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+export const MeetingIdViewHeader = ({
+  meetingId,
+  meetingName,
+  onEdit,
+  onRemove,
+}: AgentIdViewHeaderProps) => {
+  return (
+    <div className="flex items-center justify-between">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink asChild className="font-medium text-xl">
+              <Link href="/meetings">My Meetings</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator className="text-foreground text-xl font-medium [&>svg]:size-4" />
+          <BreadcrumbItem>
+            <BreadcrumbLink
+              asChild
+              className="font-medium text-xl text-foreground"
+            >
+              <Link href={`/meetings/${meetingId}`}>{meetingName}</Link>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" size="icon">
+            <MoreVerticalIcon />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onEdit}>
+            <PencilIcon className="size-4 text-black" /> Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onRemove}>
+            <TrashIcon className="size-4 text-black" /> Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};

--- a/src/modules/meetings/ui/components/update-meeting-dialog.tsx
+++ b/src/modules/meetings/ui/components/update-meeting-dialog.tsx
@@ -1,31 +1,31 @@
 import { ResponsiveDialog } from "@/components/responsive-dialog";
 import { MeetingForm } from "./meeting-form";
-import { useRouter } from "next/navigation";
+import { MeetingGetOne } from "../../types";
 
-interface NewMeetingDialogProps {
+interface UpdateMeetingDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  initialValues: MeetingGetOne;
 }
 
-export const NewMeetingDialog = ({
+export const UpdateMeetingDialog = ({
   open,
   onOpenChange,
-}: NewMeetingDialogProps) => {
-  const router = useRouter();
-
+  initialValues,
+}: UpdateMeetingDialogProps) => {
   return (
     <ResponsiveDialog
-      title="New Meeting"
-      description="Create a new meeting"
+      title="Edit Meeting"
+      description="Edit the meeting details"
       open={open}
       onOpenChange={onOpenChange}
     >
       <MeetingForm
-        onSuccess={(id) => {
+        onSuccess={() => {
           onOpenChange(false);
-          router.push(`/meetings/${id}`);
         }}
         onCancel={() => onOpenChange(false)}
+        initialValues={initialValues}
       />
     </ResponsiveDialog>
   );

--- a/src/modules/meetings/ui/views/meeting-id-view.tsx
+++ b/src/modules/meetings/ui/views/meeting-id-view.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { ErrorState } from "@/components/error-state";
+import { LoadingState } from "@/components/loading-state";
+import { useTRPC } from "@/trpc/client";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { MeetingIdViewHeader } from "../components/meeting-id-view-header";
+import { useRouter } from "next/navigation";
+import { useConfirm } from "@/hooks/use-confirm";
+import { UpdateMeetingDialog } from "../components/update-meeting-dialog";
+
+interface MeetingIdViewProps {
+  meetingId: string;
+}
+
+export const MeetingIdView = ({ meetingId }: MeetingIdViewProps) => {
+  const router = useRouter();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { data } = useSuspenseQuery(
+    trpc.meetings.getOne.queryOptions({ id: meetingId })
+  );
+
+  const [updateMeetingDialogOpen, setUpdateMeetingDialogOpen] = useState(false);
+
+  const [RemoveConfirmation, confirmRemove] = useConfirm(
+    "Are you sure?",
+    `The following action will remove ${data.name}`
+  );
+
+  const removeMeeting = useMutation(
+    trpc.meetings.remove.mutationOptions({
+      onSuccess: () => {
+        queryClient.invalidateQueries(trpc.meetings.getMany.queryOptions({}));
+        // TODO: Invalidate free tier usage
+        router.push("/meetings");
+      },
+    })
+  );
+
+  const handleRemoveMeeting = async () => {
+    const ok = await confirmRemove();
+    if (!ok) return;
+    await removeMeeting.mutate({ id: meetingId });
+  };
+
+  return (
+    <>
+      <RemoveConfirmation />
+      <UpdateMeetingDialog
+        open={updateMeetingDialogOpen}
+        onOpenChange={setUpdateMeetingDialogOpen}
+        initialValues={data}
+      />
+      <div className="flex-1 py-4 px-4 md:px-8 flex flex-col gap-y-4">
+        <MeetingIdViewHeader
+          meetingId={meetingId}
+          meetingName={data.name}
+          onEdit={() => setUpdateMeetingDialogOpen(true)}
+          onRemove={handleRemoveMeeting}
+        />
+        {JSON.stringify(data, null, 2)}
+      </div>
+    </>
+  );
+};
+
+export const MeetingIdViewLoading = () => {
+  return (
+    <LoadingState
+      title="Loading meeting"
+      description="This may take a few seconds"
+    />
+  );
+};
+
+export const MeetingIdViewError = () => {
+  return (
+    <ErrorState
+      title="Error Loading Meeting"
+      description="Please try again later"
+    />
+  );
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Builds the Meeting page so users can view, edit, and delete a meeting. Adds server-side auth and prefetching, plus a remove API and richer meeting data to address Linear 19.

- **New Features**
  - New meeting page at /meetings/[meetingId] with SSR auth, React Query hydration, Suspense, and ErrorBoundary; redirects to sign-in if unauthenticated.
  - MeetingIdView: edit via UpdateMeetingDialog, delete with confirm, invalidates list, and redirects back to /meetings.
  - Header with breadcrumb and actions (Edit, Delete).
  - meetings.remove mutation; getOne now joins agent data and returns computed duration (seconds).

- **Bug Fixes**
  - NewMeetingDialog onCancel now properly closes the dialog.

<!-- End of auto-generated description by cubic. -->

