### PR TITLE
20: Meeting Variants

### DIFF
--- a/src/modules/meetings/ui/components/active-state.tsx
+++ b/src/modules/meetings/ui/components/active-state.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { VideoIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/empty-state";
+
+interface Props {
+  meetingId: string;
+}
+
+export const ActiveState = ({ meetingId }: Props) => {
+  return (
+    <div className="bg-white rounded-lg px-4 py-5 flex flex-col gap-y-8 items-center justify-center">
+      <EmptyState
+        image="/upcoming.svg"
+        title="Meeting is active"
+        description="Meeting will end once all participants have left"
+      />
+      <div className="flex flex-col-reverse lg:flex-row lg:justify-center items-center gap-2 w-full">
+        <Button asChild className="w-full lg:w-auto">
+          <Link href={`/call/${meetingId}`}>
+            <VideoIcon />
+            Join meeting
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/meetings/ui/components/cancelled-state.tsx
+++ b/src/modules/meetings/ui/components/cancelled-state.tsx
@@ -1,0 +1,13 @@
+import { EmptyState } from "@/components/empty-state";
+
+export const CancelledState = () => {
+  return (
+    <div className="bg-white rounded-lg px-4 py-5 flex flex-col gap-y-8 items-center justify-center">
+      <EmptyState
+        image="/cancelled.svg"
+        title="Meeting cancelled"
+        description="This meeting was cancelled"
+      />
+    </div>
+  );
+};

--- a/src/modules/meetings/ui/components/processing-state.tsx
+++ b/src/modules/meetings/ui/components/processing-state.tsx
@@ -1,0 +1,13 @@
+import { EmptyState } from "@/components/empty-state"
+
+export const ProcessingState = () => {
+  return (
+    <div className="bg-white rounded-lg px-4 py-5 flex flex-col gap-y-8 items-center justify-center">
+      <EmptyState
+        image="/processing.svg"
+        title="Meeting completed"
+        description="This meeting was completed, a summary will appear soon"
+      />
+    </div>
+  )
+}

--- a/src/modules/meetings/ui/components/upcoming-state.tsx
+++ b/src/modules/meetings/ui/components/upcoming-state.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { VideoIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/empty-state";
+
+interface Props {
+  meetingId: string;
+}
+
+export const UpcomingState = ({ meetingId }: Props) => {
+  return (
+    <div className="bg-white rounded-lg px-4 py-5 flex flex-col gap-y-8 items-center justify-center">
+      <EmptyState
+        image="/upcoming.svg"
+        title="Not started yet"
+        description="Once you start this meeting, a summary will appear here"
+      />
+      <div className="flex flex-col-reverse lg:flex-row lg:justify-center items-center gap-2 w-full">
+        <Button asChild className="w-full lg:w-auto">
+          <Link href={`/call/${meetingId}`}>
+            <VideoIcon />
+            Start meeting
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/meetings/ui/views/meeting-id-view.tsx
+++ b/src/modules/meetings/ui/views/meeting-id-view.tsx
@@ -13,6 +13,10 @@ import { MeetingIdViewHeader } from "../components/meeting-id-view-header";
 import { useRouter } from "next/navigation";
 import { useConfirm } from "@/hooks/use-confirm";
 import { UpdateMeetingDialog } from "../components/update-meeting-dialog";
+import { UpcomingState } from "../components/upcoming-state";
+import { ActiveState } from "../components/active-state";
+import { CancelledState } from "../components/cancelled-state";
+import { ProcessingState } from "../components/processing-state";
 
 interface MeetingIdViewProps {
   meetingId: string;
@@ -49,6 +53,12 @@ export const MeetingIdView = ({ meetingId }: MeetingIdViewProps) => {
     await removeMeeting.mutate({ id: meetingId });
   };
 
+  const isActive = data.status === "active";
+  const isUpcoming = data.status === "upcoming";
+  const isCancelled = data.status === "cancelled";
+  const isCompleted = data.status === "completed";
+  const isProcessing = data.status === "processing";
+
   return (
     <>
       <RemoveConfirmation />
@@ -64,7 +74,11 @@ export const MeetingIdView = ({ meetingId }: MeetingIdViewProps) => {
           onEdit={() => setUpdateMeetingDialogOpen(true)}
           onRemove={handleRemoveMeeting}
         />
-        {JSON.stringify(data, null, 2)}
+        {isCancelled && <CancelledState />}
+        {isProcessing && <ProcessingState />}
+        {isCompleted && <p>Completed</p>}
+        {isActive && <ActiveState meetingId={meetingId} />}
+        {isUpcoming && <UpcomingState meetingId={meetingId} />}
       </div>
     </>
   );


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds status-specific UI to the meeting detail view. Users now see clear states (upcoming, active, cancelled, processing) with Start/Join actions instead of raw JSON. Aligns with Linear 20: Meeting Variants.

- **New Features**
  - Added UpcomingState, ActiveState, CancelledState, and ProcessingState components using EmptyState visuals.
  - meeting-id-view now renders by data.status; removed JSON output. Completed shows a simple “Completed” placeholder.
  - Upcoming/Active include buttons linking to /call/:meetingId with “Start meeting” and “Join meeting”.

<!-- End of auto-generated description by cubic. -->

